### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/ducky/tools/ld.py
+++ b/ducky/tools/ld.py
@@ -82,7 +82,7 @@ def fix_section_bases(logger, info, f_out, required_bases):
 
   D('Fixing base addresses of sections')
 
-  required_bases = dict([(e.split('=')[0], str2int(e.split('=')[1])) for e in required_bases])
+  required_bases = {e.split('=')[0]: str2int(e.split('=')[1]) for e in required_bases}
 
   sections_to_fix = {}
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:happz:ducky?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:happz:ducky?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
